### PR TITLE
fix: remove unused scripts from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,11 +5,7 @@
     "main": "DataProvider.js",
     "scripts": {
         "test": "mocha --recursive dist/test",
-        "build": "tsc --p tsdeploy.json",
-        "commit": "cz",
-        "lint": "eslint . --ext .js,.ts",
-        "lint-fix": "eslint . --fix",
-        "prepare": "husky install"
+        "build": "tsc --p tsdeploy.json"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
Remove `cz`,  `husky` and `lint` scripts from `package.json`